### PR TITLE
Fixed Clear History button

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -118,22 +118,11 @@ historyEl.addEventListener("click", function(event){
     } else if (event.target.classList.contains("close")){
         historyEl.style.display="none";
     } else if (event.target.classList.contains("reset")){
-        historyEl.innerHTML="";
-        var spanClose = document.createElement("span");
-        spanClose.setAttribute("class", "close");
-        spanClose.innerHTML="&#10006;"
-        var spanContent = document.createElement("span");
-        spanContent.setAttribute("class", "historyContent");
-        var resetBtn = document.createElement("button");
-        resetBtn.setAttribute("class", "reset");
-        resetBtn.innerHTML = "Clear History";
+        historyContent.innerHTML="";
         localStorage.removeItem("previousMedia");
         localStorage.removeItem("previousKeyword");
         previousMedia = [];
         previousKeyword = [];
-        historyEl.appendChild(spanClose);
-        historyEl.appendChild(spanContent);
-        historyEl.appendChild(resetBtn);
     }
 })
 


### PR DESCRIPTION
Clear history button was causing the tracking of searches to break once clicked, causing the page to be reloaded in order to track searches again.

This button was fixed to allow continuous function of the webpage